### PR TITLE
chore: WebRTC Package의 버전을 올립니다.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/alexpiezo/WebRTC.git",
         "state": {
           "branch": null,
-          "revision": "d014e28128f1647854bb5e90207ac5341ed6385f",
-          "version": "1.1.31567"
+          "revision": "d28a85957f83337147823207668fc2ecd2428aea",
+          "version": "95.4638.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "PagecallSDK",
-            targets: ["PagecallSDK"]),
+            targets: ["PagecallSDK"])
     ],
     dependencies: [
-        .package(url: "https://github.com/alexpiezo/WebRTC.git", .upToNextMajor(from: "1.1.31567"))
+        .package(url: "https://github.com/alexpiezo/WebRTC.git", .upToNextMajor(from: "95.4638.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -28,6 +28,5 @@ let package = Package(
             ]),
         .testTarget(
             name: "PagecallSDKTests",
-            dependencies: ["PagecallSDK"]),
-    ]
-)
+            dependencies: ["PagecallSDK"])
+    ])


### PR DESCRIPTION
M1에서 빌드할 수 있도록 버전을 올립니다
쉼표는 swiftformat 아니면 swiftlint가 자동으로 삭제했습니다. .lintrc 같은 파일이 생길 때 까지는 기본 설정을 따르려고 합니다.