### PR TITLE
fix: Pagecall sample app에서 패키지를 잘 가져다 쓸 수 있도록 합니다.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,9 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "PagecallSDK",
+            path: "Sources/PagecallSDK",
             resources: [
-                .copy("Sources/PagecallSDK/PagecallNative.js")
+                .process("PagecallNative.js")
             ]),
         .binaryTarget(
             name: "AmazonChimeSDK",

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -35,7 +35,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
             self.customUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(osVersion) Safari/605.1.15"
         }
         
-        if let path = Bundle(for: type(of: self)).path(forResource: "PagecallNative", ofType: "js") {
+        if let path = Bundle.module.path(forResource: "PagecallNative", ofType: "js") {
             if let bindingJS = try? String(contentsOfFile: path, encoding: .utf8) {
                 let script = WKUserScript(source: bindingJS, injectionTime: .atDocumentStart, forMainFrameOnly: false)
                 contentController.addUserScript(script)

--- a/Sources/PagecallSDK/PagecallWebView.swift
+++ b/Sources/PagecallSDK/PagecallWebView.swift
@@ -9,7 +9,7 @@ public class PagecallWebView: WKWebView, WKScriptMessageHandler {
         fatalError("PagecallSDK: PagecallWebView cannot be instantiated from a storyboard")
     }
     
-    override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+    override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
         let contentController = WKUserContentController()
         
         configuration.mediaTypesRequiringUserActionForPlayback = []


### PR DESCRIPTION
### changed
* SDK를 사용하는 app에서 javascript 리소스를 잘 가져다 쓸 수 있도록 했습니다.

설명
번들에서 js파일을 가져다가 웹뷰에서 실행하는 코드가 있습니다. 번들된 리소스의 path를 가져오는 과정에서, 기존에는 `Bundle(for: type(of: self)).path(forResource: "PagecallNative", ofType: "js")` 를 사용하였으나 이는 절대경로 같은 판정이 있는지, SDK를 import한 sample app에서도 resource 추가를 해주어야 동작하였습니다. 그렇지 않기 위해서는 2020년 이후 권장하는 Bundle.Module 을 사용해야합니다. (`Bundle.module.path(forResource: "PagecallNative", ofType: "js")`) 그러나, Bundle에는 기본적으로 Module 속성이 없고, SDK가 빌드 되는 과정에서 아래 사진과 같은 extension이 자동으로 추가되어 타이핑이 가능한 형태입니다. 다만 알 수 없는 이유로 아래 파일이 생기지 않아 Module을 사용할 수 없어 문제를 겪었습니다.
해결: package.swift 명세에 path를 지정해주니 빌드 과정에서 'resource_bundle_accessor.swift' 가 생기게 되어 Bundle.Module이 사용 가능해졌습니다.
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/43209402/187138447-807a1ddc-ed3b-4973-88b9-6d8cdeaa2364.png">

도움이 된 자료: https://developer.apple.com/videos/play/wwdc2020/10169/, https://developer.apple.com/documentation/xcode/bundling-resources-with-a-swift-package


* init 함수를 public으로 바꾸었습니다.