### PR TITLE
fix: 블루투스 이어폰 연결이 잘 안되는 이슈 등

### DIFF
--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -72,9 +72,7 @@ class ChimeController {
         }
         audioRecorder.updateMeters()
         let averagePower = audioRecorder.averagePower(forChannel: 0)
-        print(averagePower)
         let nomalizedVolume = normalizeSoundLevel(level: averagePower)
-        print(nomalizedVolume)
         callback(nomalizedVolume, nil)
     }
 

--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -17,7 +17,7 @@ class ChimeController {
     init(emitter: WebViewEmitter) {
         self.emitter = emitter
         let audioSession = AVAudioSession.sharedInstance()
-        try? audioSession.setCategory(.playAndRecord, mode: .default, options: [])
+        try? audioSession.setCategory(.playAndRecord, mode: .default, options: [.mixWithOthers, .allowBluetooth])
 
         let documentPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let audioFilename = documentPath.appendingPathComponent("nothing.m4a")

--- a/Sources/PagecallSDK/ChimeMeetingSession.swift
+++ b/Sources/PagecallSDK/ChimeMeetingSession.swift
@@ -22,6 +22,9 @@ class ChimeMeetingSession {
     func start(callback: (Error?) -> Void) {
         do {
             try meetingSession.audioVideo.start()
+
+            _ = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(enabled: true)
+
             callback(nil)
         } catch {
             print(error)


### PR DESCRIPTION
### changed
.allowBluetooth option을 통해 첫 접속 시 블루투스 연결이 잘 안되는 이슈를 해결했습니다.
.mixWithOthers option을 통해 enterpage에서 스피커 테스트를 진행하면 마이크 연결이 해제되는 이슈를 해결했습니다. (아직 enter 이후는 이슈가 존재합니다)
voiceFocus 모드를 항상 enable합니다.