### PR TITLE
fix: 입장 후 Webview에서 audioElement가 재생되면 마이크 연결이 해제되는 문제

### DIFF
--- a/Sources/PagecallSDK/ChimeController.swift
+++ b/Sources/PagecallSDK/ChimeController.swift
@@ -82,6 +82,7 @@ class ChimeController {
                 if error != nil {
                     callback(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to start session"]))
                 } else {
+                    try? AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .default, options: [.mixWithOthers, .allowBluetooth])
                     callback(nil)
                 }
             }


### PR DESCRIPTION
ChimeSession을 시작 한 후 AVAudioSession의 카테고리를 재설정해주어 문제를 해결합니다.